### PR TITLE
Resolve issue with rounding of concept IDs in SQL queries

### DIFF
--- a/extras/createPredSkelJson.R
+++ b/extras/createPredSkelJson.R
@@ -166,7 +166,8 @@ getCohorts <- function(cohortsToCreate, baseUrl){
     writeLines(paste("Extracting cohort:", cohortsToCreate$name[i]))
     cohortDefinitions[[i]] <- ROhdsiWebApi::getCohortDefinition(cohortId = cohortsToCreate$atlasId[i], 
                                                                 baseUrl = baseUrl)
-    cohortDefinitions[[i]]$expressionSql <- RJSONIO::toJSON(cohortDefinitions[[i]]$expression)
+    cohortDefinitions[[i]]$expressionSql <- RJSONIO::toJSON(cohortDefinitions[[i]]$expression,
+                                                            digits = 23)
     cohortDefinitions[[i]]$name = cohortsToCreate$name[i]
   }
   


### PR DESCRIPTION
Concept IDs were rounded up or down if longer than a certain number of digits. Digit parameter in the SQL query conversion is now set to 23 as in the other calls to RJSONIO::toJSON to prevent this.