### PR TITLE
Add functionality to update skeleton of existing prediction package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,3 +44,4 @@ License: Apache License 2.0
 VignetteBuilder: knitr
 LazyData: TRUE
 RoxygenNote: 7.1.1
+SkeletonNote: 1.0.0

--- a/extras/updateSkeleton.R
+++ b/extras/updateSkeleton.R
@@ -1,0 +1,56 @@
+#' Updates the package with the latest skeleton features
+#'
+#' @details
+#' Fetches the latest feature and changes to the skeleton to update the existing
+#' package.
+#'
+updatePackageVersion <- function(force = FALSE) {
+  source("./extras/updateSkeletonHelper.R")
+  
+  # Get the skeleton version of the current package. The skeleton version is
+  # stored in the SkeletonNote field in the DESCRIPTION file.
+  skeletonVersion <- packageDescription(
+    pkg = "SkeletonPredictionStudy",
+    lib.loc = NULL,
+    fields = "SkeletonNote")
+  
+  # Get the name of the package that is to be updated to rename the new skeleton
+  # files accordingly.
+  packageName <- packageDescription(
+    pkg = "SkeletonPredictionStudy",
+    lib.loc = NULL,
+    fields = "Package"
+  )
+  
+  # Download the latest skeleton to a temporary location
+  packageLocation <- downLoadSkeleton(outputFolder = tempdir(),
+                                      packageName = packageName)
+  
+  # Get the version number of the downloaded/latest skeleton
+  latestSkeletonVersion <- getLatestSkeletonVersion(dir = tempdir(),
+                                                    packageName = packageName)
+  
+  # If a new version is available?
+  if (compareVersion(skeletonVersion, latestSkeletonVersion) == 0 && !force) {
+    print("Package skeleton is up-to-date.")
+  } else if (compareVersion(skeletonVersion, latestSkeletonVersion) == -1 || force) {
+    print(paste0("Your current version is ", skeletonVersion, " and version ",
+                 latestSkeletonVersion, " is available. Updating.."))
+    
+    # replace name of downloaded skeleton
+    replaceName(packageLocation = packageLocation,
+                packageName = packageName)
+    
+    # Copy latest files from R folder to project
+    file.copy(file.path(file.path(packageLocation, "R"),dir(file.path(packageLocation, "R"))),
+              file.path(getwd(), "R"),
+              recursive = TRUE, overwrite = TRUE)
+    
+    # Update skeleton version number in DESCRIPTION file
+    desc::desc_set(SkeletonNote = latestSkeletonVersion)
+    print("Update successful")
+  } else {
+    # do nothing
+    print("Your skeleton version is ahead, this must be a mistake...")
+  }
+}

--- a/extras/updateSkeletonHelper.R
+++ b/extras/updateSkeletonHelper.R
@@ -1,0 +1,56 @@
+# code to use skeleton master from github rather than hydra
+# download a .zip file of the repository
+# from the "Clone or download - Download ZIP" button
+# on the GitHub repository of interest
+downLoadSkeleton <- function(outputFolder,
+                             packageName,
+                             skeletonType = 'SkeletonPredictionStudy'){
+  # check outputFolder exists
+  
+  # check file.path(outputFolder,  packageName) does not exist
+  
+  # download, unzip and rename:
+  
+  download.file(url = paste0("https://github.com/ohdsi/",skeletonType,"/archive/master.zip")
+                , destfile = file.path(outputFolder, "package.zip"))
+  # unzip the .zip file
+  unzip(zipfile = file.path(outputFolder, "package.zip"), exdir = outputFolder)
+  file.rename( from = file.path(outputFolder, paste0(skeletonType, '-master')),
+               to = file.path(outputFolder,  packageName))
+  unlink(file.path(outputFolder, "package.zip"))
+  return(file.path(outputFolder, packageName))
+}
+
+# change name
+replaceName <- function(packageLocation = getwd(),
+                        packageName = 'ValidateRCRI',
+                        skeletonType = 'SkeletonPredictionStudy'){
+  
+  filesToRename <- c(paste0(skeletonType,".Rproj"),paste0("R/",skeletonType,".R"))
+  for(f in filesToRename){
+    ParallelLogger::logInfo(paste0('Renaming ', f))
+    fnew <- gsub(skeletonType, packageName, f)
+    file.rename(from = file.path(packageLocation,f), to = file.path(packageLocation,fnew))
+  }
+  
+  filesToEdit <- c(file.path(packageLocation,"DESCRIPTION"),
+                   file.path(packageLocation,"README.md"),
+                   file.path(packageLocation,"extras/CodeToRun.R"),
+                   file.path(packageLocation, "extras/updateSkeleton.R"),
+                   dir(file.path(packageLocation,"R"), full.names = T))
+  for( f in filesToEdit ){
+    ParallelLogger::logInfo(paste0('Editing ', f))
+    x <- readLines(f)
+    y <- gsub( skeletonType, packageName, x )
+    cat(y, file=f, sep="\n")
+    
+  }
+  
+  return(packageName)
+}
+
+getLatestSkeletonVersion <- function(dir, packageName) {
+  packageDescription(packageName,
+                     lib.loc = dir,
+                     fields = "Version")
+}


### PR DESCRIPTION
For this, a new field (`SkeletonNote:`) has been added in `DESCRIPTION` that should be kept up-to-date with the skeleton version. In practice that means whenever the skeleton field `Version:` is updated, the same value should be copied also to `SkeletonNote:`.

This is currently implemented in a way that the feature works only once merged into the `master` branch.