### PR TITLE
Fix splitSeed is null

### DIFF
--- a/R/BackwardsComp.R
+++ b/R/BackwardsComp.R
@@ -88,6 +88,13 @@ backwards <- function(predictionAnalysisListFile){
     splitType <- 'subject'
   }
   
+  # If splitSeed is NULL then give a default SplitSeed
+  if(is.null(json$runPlpArgs$splitSeed)){
+    splitSeed <- sample(1e+05, 1)
+  } else {
+    splitSeed <- json$runPlpArgs$splitSeed
+  }
+  
   json$splitSettings <- PatientLevelPrediction::createDefaultSplitSetting(
     testFraction = json$runPlpArgs$testFraction, 
     splitSeed = json$runPlpArgs$splitSeed, 

--- a/R/BackwardsComp.R
+++ b/R/BackwardsComp.R
@@ -97,7 +97,7 @@ backwards <- function(predictionAnalysisListFile){
   
   json$splitSettings <- PatientLevelPrediction::createDefaultSplitSetting(
     testFraction = json$runPlpArgs$testFraction, 
-    splitSeed = json$runPlpArgs$splitSeed, 
+    splitSeed = splitSeed, 
     nfold = json$runPlpArgs$nfold, 
     type = splitType
     )


### PR DESCRIPTION
When a splitSeed is null in the JSON file, then the backwards function throws an error like this.

```r
splitSeed should be of class:numericsplitSeed should be of class:integer
Error in checkIsClass(splitSeed, c("numeric", "integer")) : 
  splitSeed is wrong class
```

That is because the NULL is into the createDefaultSplitSetting function, so before running this, a default seed should be given.